### PR TITLE
fix: add a limit to the query and filtering with the sharing table an…

### DIFF
--- a/force-app/main/default/lwc/orgcheckApp/api/dataset/orgcheck-api-dataset-objects.js
+++ b/force-app/main/default/lwc/orgcheckApp/api/dataset/orgcheck-api-dataset-objects.js
@@ -34,7 +34,9 @@ export class OrgCheckDatasetObjects extends OrgCheckDataset {
                         'FROM EntityDefinition ' +
                         `WHERE PublisherId IN ('System', '<local>', '${localNamespace}') ` +
                         'AND keyPrefix <> null '+
-                        'AND DeveloperName <> null '
+                        'AND DeveloperName <> null '+
+                        `AND (NOT(keyPrefix IN ('00a', '017', '0D5', '02c', '01j', '0jE','0Jf','0Ob','00I','0aA'))) `+ // filtering the feed, share, history, ...
+                        'LIMIT 2000 ' // Just to make sure we are not throwing EXCEEDED_ID_LIMIT and still got the first 2000 rows
             }])
         ])
 


### PR DESCRIPTION
…d friends When load the app for the first time i have the error: EXCEEDED_ID_LIMIT: EntityDefinition does not support queryMore(), use LIMIT to restrict the results to a single batch #429