### PR TITLE
Fix: Apex Trigger flag as containing DML #617

### DIFF
--- a/build/src/api/core/orgcheck-api-codescanner.js
+++ b/build/src/api/core/orgcheck-api-codescanner.js
@@ -3,7 +3,7 @@ const REGEX_APEXCODE_ISENUM = new RegExp("(?:public|global)\\s+(?:enum)\\s+\\w+\
 const REGEX_APEXCODE_ISTESTSEEALLDATA = new RegExp("@IsTest\\s*\\(.*SeeAllData=true.*\\)", 'i');
 const REGEX_APEXCODE_TESTNBASSERTS = new RegExp("(System.assert(Equals|NotEquals|)\\s*\\(|Assert\\.[a-zA-Z]*\\s*\\()", 'ig');
 const REGEX_APEXCODE_HASSOQL = new RegExp("\\[\\s*(?:SELECT|FIND)");
-const REGEX_APEXCODE_HASDML = new RegExp("(?:insert|update|delete)\\s*(?:\\s\\w+|\\(|\\[)");
+const REGEX_APEXCODE_HASDML = new RegExp("\\b(?:insert|update|delete)\\s*(?:\\s\\w+|\\(|\\[)");
 const REGEX_ALLCODE_COMMENTS_AND_NEWLINES = new RegExp('(\\/\\*[\\s\\S]*?\\*\\/|\\/\\/.*\\n|\\/\\/[^\\n]*|\\n)', 'gi');
 const REGEX_XML_COMMENTS_AND_NEWLINES = new RegExp('(<!--[\\s\\S]*?-->|\\n)', 'gi');
 const REGEX_HARDCODEDURLS = new RegExp("([A-Za-z0-9-]{1,63}\\.)+[A-Za-z]{2,6}", 'ig');

--- a/build/test/api/unit/orgcheck-api-codescanner.unit.test.js
+++ b/build/test/api/unit/orgcheck-api-codescanner.unit.test.js
@@ -197,6 +197,69 @@ describe('tests.api.unit.CodeScanner', () => {
       expect(hasDML).toBeDefined();
       expect(hasDML).toBe(true);
     });
+
+    it('checks if the source code contains a DML update statement', () => {
+      expect(CodeScanner.HasDMLFromApexCode('update accounts;')).toBe(true);
+    });
+
+    it('checks if the source code contains a DML delete statement', () => {
+      expect(CodeScanner.HasDMLFromApexCode('delete accounts;')).toBe(true);
+    });
+
+    it('checks if Database.insert is detected as DML', () => {
+      expect(CodeScanner.HasDMLFromApexCode('Database.insert(accounts);')).toBe(true);
+    });
+
+    it('checks if Database.update is detected as DML', () => {
+      expect(CodeScanner.HasDMLFromApexCode('Database.update(accounts);')).toBe(true);
+    });
+
+    it('checks if Database.delete is detected as DML', () => {
+      expect(CodeScanner.HasDMLFromApexCode('Database.delete(accounts);')).toBe(true);
+    });
+
+    it('checks if trigger handler methods are NOT detected as DML (false positive fix)', () => {
+      // This is a trigger that delegates to a handler - no actual DML in this code
+      const triggerCode = `trigger crm_AccountTrigger on Account (before insert, before update, before delete, after insert, after update, after delete, after undelete) {
+        crm_AccountTriggerHandler accountTriggerHandler = new crm_AccountTriggerHandler();
+        if (Trigger.isBefore && Trigger.isInsert) {
+            accountTriggerHandler.beforeInsert(Trigger.new);
+        }
+        if (Trigger.isBefore && Trigger.isUpdate) {
+            accountTriggerHandler.beforeUpdate(Trigger.old, Trigger.new, Trigger.oldMap, Trigger.newMap);
+        }
+        if (Trigger.isBefore && Trigger.isDelete) {
+            accountTriggerHandler.beforeDelete(Trigger.old, Trigger.oldMap);
+        }
+        if (Trigger.isAfter && Trigger.isInsert) {
+            accountTriggerHandler.afterInsert(Trigger.new, Trigger.newMap);
+        }
+        if (Trigger.isAfter && Trigger.isUpdate) {
+            accountTriggerHandler.afterUpdate(Trigger.old, Trigger.new, Trigger.oldMap, Trigger.newMap);
+        }
+        if (Trigger.isAfter && Trigger.isDelete) {
+            accountTriggerHandler.afterDelete(Trigger.old, Trigger.oldMap);
+        }
+        if (Trigger.isAfter && Trigger.isUndelete) {
+            accountTriggerHandler.afterUndelete(Trigger.new, Trigger.newMap);
+        }
+      }`;
+      expect(CodeScanner.HasDMLFromApexCode(triggerCode)).toBe(false);
+    });
+
+    it('checks that method names containing insert/update/delete keywords are NOT detected as DML', () => {
+      expect(CodeScanner.HasDMLFromApexCode('handler.beforeInsert(records);')).toBe(false);
+      expect(CodeScanner.HasDMLFromApexCode('handler.afterInsert(records);')).toBe(false);
+      expect(CodeScanner.HasDMLFromApexCode('handler.beforeUpdate(records);')).toBe(false);
+      expect(CodeScanner.HasDMLFromApexCode('handler.afterUpdate(records);')).toBe(false);
+      expect(CodeScanner.HasDMLFromApexCode('handler.beforeDelete(records);')).toBe(false);
+      expect(CodeScanner.HasDMLFromApexCode('handler.afterDelete(records);')).toBe(false);
+    });
+
+    it('checks if code with no DML returns false', () => {
+      expect(CodeScanner.HasDMLFromApexCode('String s = "hello";')).toBe(false);
+      expect(CodeScanner.HasDMLFromApexCode('Account a = new Account();')).toBe(false);
+    });
   });
 
 });


### PR DESCRIPTION
This PR attempts to resolve https://github.com/SalesforceLabs/OrgCheck/issues/617

Changes included:

1. The DML detection regex was matching method names like
  beforeInsert(, afterUpdate(, etc. because insert, update, delete are
  substrings of those names. Fix is aplied in build/src/api/core/orgcheck-api-codescanner.js:6:

Before:
```js  
  const REGEX_APEXCODE_HASDML = new
  RegExp("(?:insert|update|delete)\\s*(?:\\s\\w+|\\(|\\[)");
```
After:
```js
  const REGEX_APEXCODE_HASDML = new
  RegExp("\\b(?:insert|update|delete)\\s*(?:\\s\\w+|\\(|\\[)");
```
  Adding `\b` (word boundary) ensures the regex only matches standalone insert,  
  update, delete keywords, not when they're part of larger identifiers like    
  beforeInsert. 

2.  Added tests to prevent regression:
  - Test with your exact trigger handler code pattern
  - Tests for individual handler methods (beforeInsert, afterUpdate, etc.)     
  - Tests confirming Database.insert(), Database.update(), Database.delete()   
  still get detected correctly