### PR TITLE
fix(build): pin TypeScript to 5.9.x so the API bundle builds

### DIFF
--- a/packages/orgcheck-api/package.json
+++ b/packages/orgcheck-api/package.json
@@ -21,7 +21,7 @@
         "rollup-plugin-typescript2": "^0.37.0",
         "ts-jest": "^29.4.6",
         "tslib": "^2.8.1",
-        "typescript": "^7.0.2",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.56.0"
     },
     "scripts": {

--- a/packages/orgcheck-sfdx-plugin/package.json
+++ b/packages/orgcheck-sfdx-plugin/package.json
@@ -24,7 +24,7 @@
     "prettier": "^3.4.2",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
-    "typescript": "^7.0.2"
+    "typescript": "^5.9.3"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
`yarn workspace @orgcheck/api build` fails on a clean install of `main`:

```
[!] TypeError: Cannot read properties of undefined (reading 'ES2015')
    at node_modules/@rollup/plugin-typescript/dist/es/index.js:528
```

`orgcheck-api` and `orgcheck-sfdx-plugin` declare `"typescript": "^7.0.2"`, which resolves to TypeScript 7, the native rewrite. Its JS API no longer exposes `ScriptTarget` and `ModuleKind` the way `@rollup/plugin-typescript@12.3.0` expects, so the plugin's module-kind validation reads `undefined` at import time. `ts-jest@29` also caps at `peer typescript ">=4.3 <7"`.

This pins both packages to the 5.9 line, the highest version both tools support.

Verified on macOS 26.5, Node 24.18, Yarn 4.18:

* `dist/orgcheck.js` and `dist/orgcheck.d.ts` are produced and the bundled test passes
* API suite 205/205, LWC jest 18/18
* the salesforce-app static resource builds from the new bundle and deploys unmanaged to a sandbox

One note that is out of scope here: on Yarn 4 the `pack` step that follows the rollup build still fails, because Yarn 4 names the tarball `package.tgz` while `postpack` moves `orgcheck-api-*.tgz`. That is independent of the TypeScript version and does not affect the bundle.
